### PR TITLE
Update to v21.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.0 - 2022-07-08
+
+### Added
+
+- Published protobuf definitions from:
+    ```
+    tag: oss-v21.10.5
+    commit: c356d1f4a554010f30095fd088d2c72bc3c85b2a
+    ```
+
 ## 2.1.4 - 2021-01-17
 
 ### Fixed

--- a/src/event_store_db_gpb_protobufs.app.src
+++ b/src/event_store_db_gpb_protobufs.app.src
@@ -1,6 +1,6 @@
 {application,event_store_db_gpb_protobufs,
              [{description,"gpb generated protobuf definitions for EventStoreDB v20+"},
-              {vsn,"2.1.4"},
+              {vsn,"2.2.0"},
               {registered,[]},
               {applications,[kernel,stdlib]},
               {licenses,["Apache-2.0"]},

--- a/src/event_store_db_gpb_protobufs.erl
+++ b/src/event_store_db_gpb_protobufs.erl
@@ -2,7 +2,7 @@
 -export([version/0, commit_hash/0]).
 
 version() ->
-  {21, 10, 0}.
+  {21, 10, 5}.
 
 commit_hash() ->
-  "076363440415a834a5d282aed556438cdcc6d434".
+  "c356d1f4a554010f30095fd088d2c72bc3c85b2a".


### PR DESCRIPTION
Updates protos to v21.10.5 tag.

I bumped a minor version instead of a batch, since the `deadline` option change in `BatchAppendReq` breaks current version of `spear`. 

See: https://github.com/NFIBrokerage/spear/pull/72/