### PR TITLE
Generate protobufs for 23.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## 2.4.0 - 2023-12-20
+
+### Added
+
+- Published protobuf definitions from:
+    ```
+    tag: oss-v23.10.0
+    commit: "8660912b8298fa0e9c5b5fbe9d6dcecfdcbe324f"
+    ```
+
 ## 2.3.0 - 2023-03-15
 
 ### Added

--- a/src/event_store_db_gpb_protobufs.app.src
+++ b/src/event_store_db_gpb_protobufs.app.src
@@ -1,6 +1,6 @@
 {application,event_store_db_gpb_protobufs,
              [{description,"gpb generated protobuf definitions for EventStoreDB v20+"},
-              {vsn,"2.3.0"},
+              {vsn,"2.4.0"},
               {registered,[]},
               {applications,[kernel,stdlib]},
               {licenses,["Apache-2.0"]},

--- a/src/event_store_db_gpb_protobufs.erl
+++ b/src/event_store_db_gpb_protobufs.erl
@@ -2,7 +2,7 @@
 -export([version/0, commit_hash/0]).
 
 version() ->
-  {22, 10, 1}.
+  {23, 10, 0}.
 
 commit_hash() ->
-  "0e8ffb887cd35dc3e9080b2cc4f079ac720d490f".
+  "8660912b8298fa0e9c5b5fbe9d6dcecfdcbe324f".


### PR DESCRIPTION
This pull request prepares generating the protobufs from 23.10.0, which is a requirement in order for spear to support 23.10.